### PR TITLE
Update Bender.yml file with pulp-platform dependency & build order

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,8 +7,8 @@ package:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
-  fpnew: { git: "git@github.com:pulp-platform/fpnew.git", version: 0.6.4 }
-  riscv: { git: "git@github.com:pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev1"}
+  fpnew: { git: "https://github.com/pulp-platform/fpnew", version: 0.6.4 }
+  riscv: { git: "https://github.com/pulp-platform/cv32e40p", rev: "pulpissimo-v3.4.0-rev1"}
 
 sources:
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this

--- a/Bender.yml
+++ b/Bender.yml
@@ -8,23 +8,31 @@ package:
 
 dependencies:
   fpnew: { git: "git@github.com:pulp-platform/fpnew.git", version: 0.6.4 }
-  riscv: { git: "git@github.com:micprog/cv32e40p.git", rev: "pulpissimo-v3.4.1"} # To be updated to openhwgroup repository
+  riscv: { git: "git@github.com:pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev1"}
 
 sources:
+  # Source files grouped in levels. Files in level 0 have no dependencies on files in this
+  # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
+  # levels 1 and 0, etc. Files within a level are ordered alphabetically.
+  # Level 0
   - FP_WRAP/fp_iter_divsqrt_msv_wrapper_2_STAGE.sv
   - FP_WRAP/fpnew_wrapper.sv
-  - RTL/AddressDecoder_Req_FPU.sv
   - RTL/AddressDecoder_Resp_FPU.sv
-  - RTL/ArbitrationTree_FPU.sv
   - RTL/FanInPrimitive_Req_FPU.sv
   - RTL/FanInPrimitive_Resp_FPU.sv
-  - RTL/optimal_alloc.sv
   - RTL/FPU_clock_gating.sv
-  - RTL/LFSR_FPU.sv
-  - RTL/RequestBlock_FPU.sv
-  - RTL/ResponseBlock_FPU.sv
-  - RTL/ResponseTree_FPU.sv
-  - RTL/RR_Flag_Req_FPU.sv
-  - RTL/shared_fpu_cluster.sv
   - RTL/fpu_demux.sv
+  - RTL/LFSR_FPU.sv
+  - RTL/optimal_alloc.sv
+  - RTL/RR_Flag_Req_FPU.sv
+  # Level 1
+  - RTL/AddressDecoder_Req_FPU.sv
+  - RTL/ArbitrationTree_FPU.sv
+  - RTL/RequestBlock_FPU.sv
+  - RTL/ResponseTree_FPU.sv
+  # Level 2
+  - RTL/ResponseBlock_FPU.sv
+  # Level 3
   - RTL/XBAR_FPU.sv
+  # Level 4
+  - RTL/shared_fpu_cluster.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -7,8 +7,8 @@ package:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
-  fpnew: { git: "https://github.com/pulp-platform/fpnew", version: 0.6.4 }
-  riscv: { git: "https://github.com/pulp-platform/cv32e40p", rev: "pulpissimo-v3.4.0-rev1"}
+  fpnew: { git: "https://github.com/pulp-platform/fpnew.git", version: 0.6.4 }
+  riscv: { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev2"}
 
 sources:
   # Source files grouped in levels. Files in level 0 have no dependencies on files in this


### PR DESCRIPTION
This removes a link to a private repo and clarifies build in the Bender.yml file, as well as removing ssh github requirements from bender file by using https links.

@stmach Please let me know if anything is unclear. 
Would it be possible to add a release of this repository once merged, with semver tags? 
Would it make sense to first merge the `pipe_fpu_fix` branch to master, before adding the release?